### PR TITLE
Added homebrew library directories for Mac OS X

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,6 +8,12 @@
       'libraries': [
          'libfreenect.a',
       ],
+      'conditions': [
+        ['OS=="mac"', {
+          'include_dirs': ['/usr/local/include'],
+          'library_dirs': ['/usr/local/lib'],
+        }],
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adding these directories allows node-gyp to successfully build the project with libfreenect and libusb installed through homebrew on a Mac.
