### PR TITLE
Generalized freenect library location

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,6 +3,7 @@
     'target_name': 'kinect',
     'sources': ['src/kinect.cc'],
     'libraries': ['-lfreenect'],
+    'cflags': ['-std=c++11']
   }]
 }
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,19 +1,8 @@
 {
-  'targets': [
-    {
-      'target_name': 'kinect',
-      'sources': [
-        'src/kinect.cc',
-      ],
-      'libraries': [
-         'libfreenect.a',
-      ],
-      'conditions': [
-        ['OS=="mac"', {
-          'include_dirs': ['/usr/local/include'],
-          'library_dirs': ['/usr/local/lib'],
-        }],
-      ]
-    }
-  ]
+  'targets': [{
+    'target_name': 'kinect',
+    'sources': ['src/kinect.cc'],
+    'libraries': ['-lfreenect'],
+  }]
 }
+

--- a/src/kinect.cc
+++ b/src/kinect.cc
@@ -38,13 +38,13 @@ namespace
     {
         auto const context = static_cast<kinect::Context *>(
                 freenect_get_user(device));
+        assert(context != nullptr);
         return context;
     }
 
     void async_video_callback(uv_async_t *handle, int notUsed)
     {
         auto const context = get_kinect_context(handle);
-        assert(context != nullptr);
         context->VideoCallback();
     }
 

--- a/src/kinect.cc
+++ b/src/kinect.cc
@@ -40,12 +40,6 @@ namespace
 
 
 namespace kinect {
-
-  Context *
-  Context::GetContext(const Arguments &args) {
-    return ObjectWrap::Unwrap<Context>(args.This());
-  }
-
   /********************************/
   /********* Flow *****************/
   /********************************/
@@ -96,7 +90,7 @@ namespace kinect {
     // = Video                                                             =
     // =====================================================================
 
-    Handle<Value> Context::SetVideoCallback(const Arguments& args)
+    Handle<Value> Context::SetVideoCallback(Arguments const& args)
     {
         HandleScope scope;
         GetContext(args)->SetVideoCallback();
@@ -408,10 +402,17 @@ namespace kinect {
     return Undefined();
    }
 
+    kinect::Context *Context::GetContext(Arguments const&args)
+    {
+        return ObjectWrap::Unwrap<kinect::Context>(args.This());
+    }
+
   void
   Initialize(Handle<Object> target) {
     Context::Initialize(target);
   }
+
+
 
 }
 

--- a/src/kinect.cc
+++ b/src/kinect.cc
@@ -14,7 +14,6 @@ extern "C" {
 #include <stdio.h>
 #include <stdexcept>
 #include <string>
-//#include <iostream>
 
 #include "kinect.h"
 
@@ -312,7 +311,6 @@ namespace kinect {
 
     String::AsciiValue val(args[0]->ToString());
     GetContext(args)->Led(std::string(*val));
-    //GetContext(args)->Led(std::string("green"));
     return Undefined();
   }
 

--- a/src/kinect.cc
+++ b/src/kinect.cc
@@ -251,17 +251,17 @@ namespace kinect {
   Context::Led(const std::string option) {
     freenect_led_options ledCode;
 
-    if (option.compare("off") == 0) {
+    if (option == "off") {
       ledCode = LED_OFF;
-    } else if (option.compare("green") == 0) {
+    } else if (option == "green") {
       ledCode = LED_GREEN;
-    } else if (option.compare("red") == 0) {
+    } else if (option == "red") {
       ledCode = LED_RED;
-    } else if (option.compare("yellow") == 0) {
+    } else if (option == "yellow") {
       ledCode = LED_YELLOW;
-    } else if (option.compare("blink green") == 0) {
+    } else if (option == "blink green") {
       ledCode = LED_BLINK_GREEN;
-    } else if (option.compare("blink red yellow") == 0) {
+    } else if (option == "blink red yellow") {
       ledCode = LED_BLINK_RED_YELLOW;
     } else {
       ThrowException(Exception::Error(String::New("Did not recognize given led code")));

--- a/src/kinect.cc
+++ b/src/kinect.cc
@@ -16,6 +16,8 @@ extern "C" {
 #include <string>
 //#include <iostream>
 
+#include "kinect.h"
+
 using namespace node;
 using namespace v8;
 
@@ -23,61 +25,6 @@ namespace kinect {
 
   static Persistent<String> depthCallbackSymbol;
   static Persistent<String> videoCallbackSymbol;
-
-  class Context : ObjectWrap {
-    public:
-      static void            Initialize (v8::Handle<v8::Object> target);
-      virtual                ~Context   ();
-      void                   DepthCallback    ();
-      void                   VideoCallback    ();
-      bool                   running_;
-      bool                   sending_;
-      freenect_context*      context_;
-      uv_async_t             uv_async_video_callback_;
-      uv_async_t             uv_async_depth_callback_;
-
-    private:
-      Context(int user_device_number);
-      static Handle<Value>  New              (const Arguments& args);
-      static Context*       GetContext       (const Arguments &args);
-
-      void                  Close            ();
-      static Handle<Value>  Close            (const Arguments &args);
-
-      void                  Led              (const std::string option);
-      static Handle<Value>  Led              (const Arguments &args);
-
-      void                  Tilt             (const double angle);
-      static Handle<Value>  Tilt             (const Arguments &args);
-
-      void                  SetDepthCallback ();
-      static Handle<Value>  SetDepthCallback (const Arguments &args);
-
-      void                  SetVideoCallback ();
-      static Handle<Value>  SetVideoCallback (const Arguments &args);
-
-      void                  Pause            ();
-      static Handle<Value>  Pause            (const Arguments &args);
-
-      void                  Resume           ();
-      static Handle<Value>  Resume           (const Arguments &args);
-
-      void                  InitProcessEventThread();
-
-      bool                  depthCallback_;
-      bool                  videoCallback_;
-      Buffer*               videoBuffer_;
-      Handle<Value>         videoBufferPersistentHandle_;
-      Buffer*               depthBuffer_;
-      Handle<Value>         depthBufferPersistentHandle_;
-
-      freenect_device*      device_;
-      freenect_frame_mode   videoMode_;
-      freenect_frame_mode   depthMode_;
-
-      uv_thread_t           event_thread_;
-
-  };
 
   Context *
   Context::GetContext(const Arguments &args) {

--- a/src/kinect.h
+++ b/src/kinect.h
@@ -1,0 +1,68 @@
+#ifndef KINECT_H
+#define KINECT_H
+
+#include <string>
+#include <node.h>
+
+namespace kinect {
+
+  class Context : node::ObjectWrap {
+    public:
+      static void            Initialize (v8::Handle<v8::Object> target);
+      virtual                ~Context   ();
+      void                   DepthCallback    ();
+      void                   VideoCallback    ();
+      bool                   running_;
+      bool                   sending_;
+      freenect_context*      context_;
+      uv_async_t             uv_async_video_callback_;
+      uv_async_t             uv_async_depth_callback_;
+
+    private:
+      Context(int user_device_number);
+
+      static v8::Handle<v8::Value>  New              (const v8::Arguments& args);
+      static Context*               GetContext       (const v8::Arguments &args);
+
+      void                          Close            ();
+      static v8::Handle<v8::Value>  Close            (const v8::Arguments &args);
+
+      void                          Led              (const std::string option);
+      static v8::Handle<v8::Value>  Led              (const v8::Arguments &args);
+
+      void                          Tilt             (const double angle);
+      static v8::Handle<v8::Value>  Tilt             (const v8::Arguments &args);
+
+      void                          SetDepthCallback ();
+      static v8::Handle<v8::Value>  SetDepthCallback (const v8::Arguments &args);
+
+      void                          SetVideoCallback ();
+      static v8::Handle<v8::Value>  SetVideoCallback (const v8::Arguments &args);
+
+      void                          Pause            ();
+      static v8::Handle<v8::Value>  Pause            (const v8::Arguments &args);
+
+      void                          Resume           ();
+      static v8::Handle<v8::Value>  Resume           (const v8::Arguments &args);
+
+      void                          InitProcessEventThread();
+
+      bool                  depthCallback_;
+      bool                  videoCallback_;
+      node::Buffer*         videoBuffer_;
+      v8::Handle<v8::Value> videoBufferPersistentHandle_;
+      node::Buffer*         depthBuffer_;
+      v8::Handle<v8::Value> depthBufferPersistentHandle_;
+
+      freenect_device*      device_;
+      freenect_frame_mode   videoMode_;
+      freenect_frame_mode   depthMode_;
+
+      uv_thread_t           event_thread_;
+
+  };
+
+}
+
+#endif  // KINECT_H
+


### PR DESCRIPTION
Hi, thanks for wrapping freenect.

I had to change `binding.gyp` to make it compile on my Arch Linux box. I've not used GYP much, but I think I've generalized the location of the freenect library and it type (e.g., .so or .a).

Apparently `gcc` searches `/usr/local/lib/` and `/usr/lib/` by default for libraries so I'd guess it still compiles on your OSX box.

Thanks, Pete.
